### PR TITLE
bluetooth_6lowpand: make date format compatible with busybox

### DIFF
--- a/bluetooth_6lowpand.sh
+++ b/bluetooth_6lowpand.sh
@@ -103,7 +103,7 @@ option_loglevel="$(conf_find_value "LOG_LEVEL" "${LOG_LEVEL_INFO}")"
 function write_log {
 	if [ "${option_loglevel}" -ge "${1}" ]; then
 		shift
-		echo "$(date +%Y%m%d-%k%M%S) ${@}" >&2
+		echo "$(date +%F-%T) ${@}" >&2
 	fi
 }
 


### PR DESCRIPTION
date +%F-%T (e.g. 2017-05-15-19:15:11) is also compatible with busybox.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>